### PR TITLE
Update apply_delta.py

### DIFF
--- a/toolbench/model/apply_delta.py
+++ b/toolbench/model/apply_delta.py
@@ -98,11 +98,10 @@ def apply_delta_low_cpu_mem(base_model_path, target_model_path, delta_path):
             file_name = f"pytorch_model-{i}.bin"
             for name, param in state_dict.items():
                 if name not in delta_state_dict:
-                    for delta_file in delta_files:
-                        delta_state_dict = torch.load(delta_file)
-                        gc.collect()
-                        if name in delta_state_dict:
-                            break
+                    if name in weight_map:
+                        state_dict[name] = weight_map[name]
+                    else:
+                        continue
 
                 state_dict[name] += delta_state_dict[name]
                 weight_map[name] = file_name
@@ -120,6 +119,8 @@ def apply_delta_low_cpu_mem(base_model_path, target_model_path, delta_path):
     print(f"Saving the target model to {target_model_path}")
     delta_tokenizer.save_pretrained(target_model_path)
     delta_config.save_pretrained(target_model_path)
+
+
 
 
 def apply_delta(base_model_path, target_model_path, delta_path):


### PR DESCRIPTION
In the `apply_delta_low_cpu_mem()` function, the for loop in the if name not in delta_state_dict: clause will iterate over all of the parameters in the base model's state dict, even if the `delta_state_dict` does not contain all of the parameters. This can lead to a significant memory leak, as the `delta_state_dict` will be loaded into memory even if it is not used. I guess we can add a check to the if name not in `delta_state_dict:` clause to see if the parameter is already in the `weight_map` dictionary. If it is, then there is no need to load the parameter from the `delta_state_dict`, as it will already be in the target model's state dict.