### PR TITLE
Update preprocess_toolllama_data.py

### DIFF
--- a/preprocess/preprocess_toolllama_data.py
+++ b/preprocess/preprocess_toolllama_data.py
@@ -29,8 +29,7 @@ def preprocess_rapidapi(tool_data_dir, method, output_file):
     def append_list(instances_list: list) -> list:
         return_list = []
         for instances in instances_list:
-            for instance in instances:
-                return_list.append(instance)
+            return_list.extend(instances)
         return return_list
 
     print(f"Preprocessing data from {tool_data_dir} into {output_file}")


### PR DESCRIPTION
`append_list()` function is called recursively to append the list of instances to the output list. However, each time the function is called, it creates a new list. This means that the output list will contain a nested list of lists, which can be inefficient. A better way to implement the `append_list()` function would be to use a single list like this: