### PR TITLE
Bug Fix: Failure to initialize the model state after an exception resulted in the inability to continue the conversation.

### DIFF
--- a/toolbench/inference/toolbench_server.py
+++ b/toolbench/inference/toolbench_server.py
@@ -144,7 +144,11 @@ def stream():
                     print(obj)
                     print(e)
 
-            future.result()
+            try:
+                future.result()
+            except Exception as e:
+                model.inuse = False
+                print(e)
 
         model.inuse = False
         return


### PR DESCRIPTION
Start the toolbench_server, if errors occur in the pipeline, such as
![image](https://github.com/OpenBMB/ToolBench/assets/52190211/a2137d98-7304-4c67-93dd-837eb4265767)
When I try to ask a new question again, the model's state wasn't initialized properly due to the previous exception, preventing me from making a second attempt.
![image](https://github.com/OpenBMB/ToolBench/assets/52190211/ec5a91b2-40b5-49fe-b04a-a92f53e519e2)
The reason is on line 124 of the toolbench_server script, where the run_pipeline function is passed to the thread pool for execution. If an exception occurs in the run_pipeline function, the model initialization code on lines 142 and 149 will not be executed because Python exceptions cannot propagate across threads. Therefore, exception handling needs to be added before and after line 147.