### PR TITLE
Add support for Palm, Claude-2, Cohere, Azure OpenAI, Replicate Llama2 CodeLlama, Ollama, (100+LLMs) 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ langchain==0.0.229
 deepspeed==0.9.2
 sentence_transformers==2.2.2
 tensorboard
+litellm
 openai
 scipy
 termcolor

--- a/toolbench/inference/LLM/chatgpt_function_model.py
+++ b/toolbench/inference/LLM/chatgpt_function_model.py
@@ -1,5 +1,6 @@
 import json
 import openai
+import litellm
 from tenacity import retry, wait_random_exponential, stop_after_attempt
 from termcolor import colored
 import time
@@ -33,7 +34,7 @@ def chat_completion_request(key, messages, functions=None,function_call=None,key
             openai.api_key = key
         else:
             raise NotImplementedError
-        openai_response = openai.ChatCompletion.create(
+        openai_response = litellm.completion(
             **json_data,
         )
         json_data = json.loads(str(openai_response))

--- a/toolbench/tooleval/evaluators/registered_cls/utils.py
+++ b/toolbench/tooleval/evaluators/registered_cls/utils.py
@@ -40,7 +40,7 @@ class OpenaiPoolRequest:
 
     @retry(wait=wait_random_exponential(multiplier=1, max=30), stop=stop_after_attempt(10),reraise=True)
     def request(self,messages,**kwargs):
-        import openai
+        import litellm
         import random
         
         item = random.choice(self.pool)
@@ -48,7 +48,7 @@ class OpenaiPoolRequest:
         
         if item.get('organization',None) is not None:
             kwargs['organization'] = item['organization'] 
-        return openai.ChatCompletion.create(messages=messages,**kwargs)
+        return litellm.completion(messages=messages,**kwargs)
     
     def __call__(self,messages,**kwargs):
         return self.request(messages,**kwargs)


### PR DESCRIPTION
This PR adds support for the above mentioned LLMs using LiteLLM https://github.com/BerriAI/litellm/ 
LiteLLM is a lightweight package to simplify LLM API calls - use any llm as a drop in replacement for gpt-3.5-turbo. 

Example
```python
from litellm import completion

## set ENV variables
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# cohere call
response = completion(model="command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```