### PR TITLE
Bug Fix: KeyError and Repeat Counts in evaluation

### DIFF
--- a/toolbench/tooleval/eval_preference.py
+++ b/toolbench/tooleval/eval_preference.py
@@ -175,6 +175,8 @@ if __name__=='__main__':
                 for qid in test_ids:
                     if qid not in prefer_dict:
                         prefer_dict[qid] = {reference_model: 0, output_model: 0, f"round_{i}": "incomplete"}
+                    elif f"round_{i}" not in prefer_dict[qid]:
+                        prefer_dict[qid][f"round_{i}"] = "incomplete"
                     elif prefer_dict[qid][f"round_{i}"] == "complete":
                         continue
                     if qid in ref_pass_result_dict and qid in output_pass_result_dict:

--- a/toolbench/tooleval/eval_preference.py
+++ b/toolbench/tooleval/eval_preference.py
@@ -182,17 +182,21 @@ if __name__=='__main__':
                     if qid in ref_pass_result_dict and qid in output_pass_result_dict:
                         if ref_pass_result_dict[qid]["machine_label"] == "passed" and output_pass_result_dict[qid]["machine_label"] == "failed":
                             prefer_dict[qid][reference_model] += 1
+                            prefer_dict[qid][f"round_{i}"] = "complete"
                             continue
                         elif ref_pass_result_dict[qid]["machine_label"] == "failed" and output_pass_result_dict[qid]["machine_label"] == "passed":
                             prefer_dict[qid][output_model] += 1
+                            prefer_dict[qid][f"round_{i}"] = "complete"
                             continue
                     
                     if qid not in reference_examples:
                         prefer_dict[qid][output_model] += 1
+                        prefer_dict[qid][f"round_{i}"] = "complete"
                         continue
                     if qid not in output_examples:
                         print(f"Query {qid} not in output model converted answers!")
                         prefer_dict[qid][reference_model] += 1
+                        prefer_dict[qid][f"round_{i}"] = "complete"
                         continue
 
                     ref_example = reference_examples[qid]


### PR DESCRIPTION
1. 进行多轮评估的时候，从第二轮开始，`qid`已经在`prefer_dict`里面了，直接进入elif会导致没有"round_1"而报错；
2. 直接进行pass rate比对的时候，`reference_model`或`output_model`已经+1了，但没有标记为`complete`。这样从文件读取再次评估的时候，似乎会重复计算这部分。