### PR TITLE
Fix arguments error in calculating ndcg_score for retrieval model

### DIFF
--- a/toolbench/retrieval/api_evaluator.py
+++ b/toolbench/retrieval/api_evaluator.py
@@ -52,7 +52,7 @@ def compute_ndcg_for_query(query_tuple):
         if hit["corpus_id"] in query_relevant_docs:
             true_relevance[corpus_ids.index(hit["corpus_id"])] = 1
 
-    return ndcg_score([true_relevance], [predicted_scores], k)
+    return ndcg_score([true_relevance], [predicted_scores], k=k)
 
 
 class APIEvaluator(SentenceEvaluator):


### PR DESCRIPTION
Hello, 

Thank you for open-sourcing your code! :)
I encountered an error while training the retrieval model, which indicated a mismatch in the number of arguments when calculating metrics. It turned out to be because the 'k' argument was not explicitly specified in the computation of ndcg_score.

Hope this helps. #208 